### PR TITLE
Process files included in .rubocop.yml

### DIFF
--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -13,7 +13,7 @@ module Pronto
 
       valid_patches = patches.select do |patch|
         patch.additions > 0 &&
-          ruby_file?(patch.new_file_full_path) &&
+          (ruby_file?(patch.new_file_full_path) || included?(patch)) &&
           !excluded?(patch)
       end
 
@@ -40,6 +40,11 @@ module Pronto
     def excluded?(patch)
       path = patch.new_file_full_path.to_s
       @config_store.for(path).file_to_exclude?(path)
+    end
+
+    def included?(patch)
+      path = patch.new_file_full_path.to_s
+      @config_store.for(path).file_to_include?(path)
     end
 
     def level(severity)


### PR DESCRIPTION
Current implementation is not considering files [explicitly included in `.rubocop.yml`](https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L11-L27) thus leaving `*.rake`, `*.jbuilder`, `Gemfile`... files unprocessed.

It takes a similar approach to the commit that solved issue #4, where you excluded files that were excluded in rubocop.yml. 