### PR TITLE
Lower rubucop version restriction

### DIFF
--- a/pronto-rubocop.gemspec
+++ b/pronto-rubocop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'rubocop', '~> 0.34.0'
+  s.add_runtime_dependency 'rubocop', '~> 0.34'
   s.add_runtime_dependency 'pronto', '~> 0.4.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
This makes `rubocop` updates possible without the need to touch the `gemspec` (so we can use the new `rubocop v0.35`). In case there is a `rubocop v1.*` sometime (with breaking changes), it still prevents this upgrade. Or is there any greater intention behind locking it at `~> 0.34.0`?