### PR TITLE
Update rubocop dependency to 0.36.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+sudo: false # Use container-based infrastructure
+before_install:
+  # Update bundler to fix issue at Travis
+  # see https://github.com/bundler/bundler/issues/3558#issuecomment-171347979
+  - gem update bundler
 rvm:
 - 1.9.3
 - 2.0.0

--- a/pronto-rubocop.gemspec
+++ b/pronto-rubocop.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency('rubocop', '~> 0.35.0')
+  s.add_runtime_dependency('rubocop', '~> 0.36.0')
   s.add_runtime_dependency('pronto', '~> 0.5.0')
   s.add_development_dependency('rake', '~> 10.4')
   s.add_development_dependency('rspec', '~> 3.3')


### PR DESCRIPTION
Release notes: https://github.com/bbatsov/rubocop/releases/tag/v0.36.0
