### PR TITLE
Specify ruby version explicitly (RuboCop 0.36.0 compatibility issue)

### DIFF
--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -53,7 +53,7 @@ module Pronto
 
     def processed_source_for(patch)
       path = patch.new_file_full_path.to_s
-      ::RuboCop::ProcessedSource.from_file(path)
+      ::RuboCop::ProcessedSource.from_file(path, RUBY_VERSION[0..2].to_f)
     end
 
     def level(severity)


### PR DESCRIPTION
Since rubocop 0.36.0 has changed method signature of `RuboCop::ProcessedSource.from_file`, we need to give a ruby version as an argument.

```
/home/ubuntu/.rvm/gems/ruby-2.2.3/gems/rubocop-0.36.0/lib/rubocop/processed_source.rb:16:in `from_file': wrong number of arguments (1 for 2) (ArgumentError)
	from /home/ubuntu/.rvm/gems/ruby-2.2.3/gems/pronto-rubocop-0.5.1/lib/pronto/rubocop.rb:56:in `processed_source_for'
	from /home/ubuntu/.rvm/gems/ruby-2.2.3/gems/pronto-rubocop-0.5.1/lib/pronto/rubocop.rb:32:in `inspect'
	from /home/ubuntu/.rvm/gems/ruby-2.2.3/gems/pronto-rubocop-0.5.1/lib/pronto/rubocop.rb:15:in `block in run'
	from /home/ubuntu/.rvm/gems/ruby-2.2.3/gems/pronto-rubocop-0.5.1/lib/pronto/rubocop.rb:15:in `map'
	from /home/ubuntu/.rvm/gems/ruby-2.2.3/gems/pronto-rubocop-0.5.1/lib/pronto/rubocop.rb:15:in `run'
```

rubocop 0.36.0 changes `from_file` arguments:
```diff
     attr_reader :path, :buffer, :ast, :comments, :tokens, :diagnostics,
                  :parser_error, :raw_source
 
-    def self.from_file(path, ruby_version = nil)
+    def self.from_file(path, ruby_version)
       file = File.read(path)
       new(file, ruby_version, path)
     rescue Errno::ENOENT
```
https://github.com/bbatsov/rubocop/commit/12c6efc9fd00be255bb9f9b4180cf35c10e59a96#diff-162ebd5807ea7283c42ed0f59b4e74d2

And pronto-rubocop 0.5.1 doesn't pass ruby_version argument:
```ruby
    def processed_source_for(patch)
      path = patch.new_file_full_path.to_s
      ::RuboCop::ProcessedSource.from_file(path)
    end
```
https://github.com/mmozuras/pronto-rubocop/blob/master/lib/pronto/rubocop.rb#L54-L57
