### PR TITLE
Relax rubocop versioning

### DIFF
--- a/pronto-rubocop.gemspec
+++ b/pronto-rubocop.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency('rubocop', '~> 0.36.0')
+  s.add_runtime_dependency('rubocop', '>= 0')
   s.add_runtime_dependency('pronto', '~> 0.5.0')
   s.add_development_dependency('rake', '~> 10.4')
   s.add_development_dependency('rspec', '~> 3.3')


### PR DESCRIPTION
Personally, I think we don't need to lock rubocop to specific version.
With this PR, an user who wants to run `pronto-rubocop` with rubocop X.Y.Z, can specifies rubocop version in their `Gemfile` like this:

```ruby
gem 'pronto-rubocop'
gem 'rubocop', '~> X.Y.Z'
```

What do you think? @mmozuras