### PR TITLE
Allow custom config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Pronto runner for [Rubocop](https://github.com/bbatsov/rubocop), ruby code analy
 ## Configuration
 
 Configuring Rubocop via .rubocop.yml will work just fine with pronto-rubocop.
+You can also specify a custom `.rubocop.yml` location with the environment variable `RUBOCOP_CONFIG`

--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -7,6 +7,7 @@ module Pronto
       super
 
       @config_store = ::RuboCop::ConfigStore.new
+      @config_store.options_config = ENV['RUBOCOP_CONFIG'] if ENV['RUBOCOP_CONFIG']
       @inspector = ::RuboCop::Runner.new({}, @config_store)
     end
 


### PR DESCRIPTION
We use pronto across projects, but can't put the `.rubocop.yml` file in the root. This allows a custom location.